### PR TITLE
feat: add charts and spending list components to dashboard

### DIFF
--- a/src/app/(app)/dashboard/components/ChartSkeleton.tsx
+++ b/src/app/(app)/dashboard/components/ChartSkeleton.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ChartSkeleton() {
+  return <Skeleton className="w-full h-60 md:h-80" />;
+}

--- a/src/app/(app)/dashboard/components/IncomeExpenseChart.tsx
+++ b/src/app/(app)/dashboard/components/IncomeExpenseChart.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts";
+import { ChartSkeleton } from "./ChartSkeleton";
+
+const chartConfig = {
+  income: {
+    label: "Income",
+    color: "hsl(var(--chart-1))",
+  },
+  expenses: {
+    label: "Expenses",
+    color: "hsl(var(--chart-2))",
+  },
+} satisfies ChartConfig;
+
+export default function IncomeExpenseChart() {
+  const [data, setData] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      const endDate = new Date();
+      const startDate = new Date();
+      startDate.setMonth(startDate.getMonth() - 6);
+
+      try {
+        const response = await fetch(
+          `/api/v1/analytics/income-expense-trend?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch data");
+        }
+        const result = await response.json();
+        setData(result);
+      } catch (error) {
+        toast.error("Could not load trend data.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (isLoading) {
+    return <ChartSkeleton />;
+  }
+
+  return (
+    <ChartContainer config={chartConfig} className="w-full h-80">
+      <BarChart data={data} accessibilityLayer>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+        />
+        <YAxis />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="income" fill="var(--color-income)" radius={4} />
+        <Bar dataKey="expenses" fill="var(--color-expenses)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/app/(app)/dashboard/components/SpendingByCategoryChart.tsx
+++ b/src/app/(app)/dashboard/components/SpendingByCategoryChart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import { PieChart, Pie, Cell } from "recharts";
+import { ChartSkeleton } from "./ChartSkeleton";
+
+export default function SpendingByCategoryChart() {
+  const [data, setData] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      const startDate = new Date();
+      startDate.setDate(1);
+      const endDate = new Date();
+
+      try {
+        const response = await fetch(
+          `/api/v1/analytics/spending-by-category?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch data");
+        }
+        const result = await response.json();
+        const formattedData = result.map((item: any) => ({
+          category: item.category.name,
+          amount: item._sum.amount,
+          color: item.category.color,
+        }));
+        setData(formattedData);
+      } catch (error) {
+        toast.error("Could not load spending data.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const chartConfig = useMemo(() => {
+    if (data.length === 0) return {};
+    return data.reduce((acc, item) => {
+      acc[item.category] = {
+        label: item.category,
+        color: item.color,
+      };
+      return acc;
+    }, {} as ChartConfig);
+  }, [data]);
+
+  if (isLoading) {
+    return <ChartSkeleton />;
+  }
+
+  if (data.length === 0) {
+    return <div className="w-full h-60 md:h-80 flex items-center justify-center">No spending data for this month.</div>;
+  }
+
+  return (
+    <ChartContainer config={chartConfig} className="w-full h-60">
+      <PieChart>
+        <ChartTooltip content={<ChartTooltipContent nameKey="amount" hideLabel />} />
+        <Pie data={data} dataKey="amount" nameKey="category" cx="50%" cy="50%" outerRadius={80}>
+          {data.map((entry) => (
+            <Cell key={entry.category} fill={`var(--color-${entry.category})`} />
+          ))}
+        </Pie>
+        <ChartLegend content={<ChartLegendContent nameKey="category" />} />
+      </PieChart>
+    </ChartContainer>
+  );
+}

--- a/src/app/(app)/dashboard/components/SpendingList.tsx
+++ b/src/app/(app)/dashboard/components/SpendingList.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Progress } from "@/components/ui/progress";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import { ChartSkeleton } from "./ChartSkeleton";
+import { formatCurrency } from "@/lib/utils";
+
+interface SpendingData {
+  category: {
+    id: string;
+    name: string;
+    color: string;
+  };
+  _sum: {
+    amount: number;
+  };
+}
+
+export default function SpendingList() {
+  const [data, setData] = useState<SpendingData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      const startDate = new Date();
+      startDate.setDate(1);
+      const endDate = new Date();
+
+      try {
+        const response = await fetch(
+          `/api/v1/analytics/spending-by-category?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch data");
+        }
+        const result = await response.json();
+        setData(result);
+      } catch {
+        toast.error("Could not load spending data.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const totalExpenses = useMemo(() => {
+    return data.reduce((acc, item) => acc + item._sum.amount, 0);
+  }, [data]);
+
+  if (isLoading) {
+    return <ChartSkeleton />;
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        No spending data for this month.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {data.map((item) => {
+        const percentage = (item._sum.amount / totalExpenses) * 100;
+        return (
+          <div key={item.category.id} className="space-y-1">
+            <div className="flex justify-between items-center">
+              <span className="text-sm font-medium">{item.category.name}</span>
+              <span className="text-sm text-muted-foreground">
+                {formatCurrency(item._sum.amount)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Progress
+                value={percentage}
+                style={
+                  { backgroundColor: `${item.category.color}33` }
+                } // Lighter background
+              />
+
+            </div>
+            <span className="text-xs w-12 text-right">
+              {percentage.toFixed(0)}% of total expenses
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import Link from "next/link";
-import { PlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,6 +15,9 @@ import TransactionMetrics, {
 } from "./components/TransactionMetrics";
 import { useRef } from "react";
 import { TTransaction } from "@/types/transaction";
+import SpendingByCategoryChart from "./components/SpendingByCategoryChart";
+import IncomeExpenseChart from "./components/IncomeExpenseChart";
+import SpendingList from "./components/SpendingList";
 
 export default function DashboardPage() {
   const transactionMatricsRef = useRef<TransactionMatricsElement>(null);
@@ -31,30 +33,59 @@ export default function DashboardPage() {
   return (
     <div className="space-y-6">
       <TransactionMetrics ref={transactionMatricsRef} />
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
-        <RecentTransactions ref={recentTransactionsRef} />
-        <Card className="col-span-4 md:col-span-3">
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-12">
+        <Card className="lg:col-span-7">
+          <CardHeader>
+            <CardTitle>Income vs. Expenses</CardTitle>
+            <CardDescription>Last 6 months</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <IncomeExpenseChart />
+          </CardContent>
+        </Card>
+        <Card className="lg:col-span-5">
+          <CardHeader>
+            <CardTitle>Spending by Category</CardTitle>
+            <CardDescription>Current month</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SpendingByCategoryChart />
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid grid-cols-1 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Spending Breakdown</CardTitle>
+            <CardDescription>Current month&apos;s expense categories</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SpendingList />
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-7">
+        <div className="lg:col-span-4">
+          <RecentTransactions ref={recentTransactionsRef} />
+        </div>
+        <Card className="lg:col-span-3">
           <CardHeader>
             <CardTitle>Quick Actions</CardTitle>
-            <CardDescription>
-              Add new transactions or view reports
-            </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-4">
             <AddTransactionDialog type="INCOME" onAdd={onAdd} />
             <AddTransactionDialog type="EXPENSE" onAdd={onAdd} />
-            <Button variant="outline" className="w-full">
+            <Button variant="outline" className="w-full as-child">
               <Link
                 href="/dashboard/reports"
                 className="flex items-center justify-center"
               >
-                <PlusIcon className="mr-2 h-4 w-4" />
                 View Reports
               </Link>
             </Button>
           </CardContent>
         </Card>
-      </div>
+      </div>̥
     </div>
   );
 }

--- a/src/app/api/v1/analytics/[slug]/route.ts
+++ b/src/app/api/v1/analytics/[slug]/route.ts
@@ -1,0 +1,22 @@
+import {
+  getIncomeExpenseTrend,
+  getSpendingByCategory,
+} from "@/lib/user/analytics";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request, { params }: { params: any }) {
+  const { searchParams } = new URL(req.url);
+  const startDate = new Date(searchParams.get("startDate") || "");
+  const endDate = new Date(searchParams.get("endDate") || "");
+
+  switch (params.slug) {
+    case "spending-by-category":
+      const spending = await getSpendingByCategory({ startDate, endDate });
+      return NextResponse.json(spending);
+    case "income-expense-trend":
+      const trend = await getIncomeExpenseTrend({ startDate, endDate });
+      return NextResponse.json(trend);
+    default:
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,18 +7,23 @@ import { cn } from "@/lib/utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string
+  }
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
       className
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn(
+        "h-full w-full flex-1 bg-primary transition-all",
+        indicatorClassName
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
This pr adds few ui elements in the dashboard which are the charts for spend in last 6 months and also the spend this month distributed over a pie chart




<img width="1071" height="471" alt="image" src="https://github.com/user-attachments/assets/c26db68f-a9a5-4cad-81c7-22745b312062" />

Also spending breakdown for a greater view of the expenses where most of it has been spent

<img width="1071" height="360" alt="image" src="https://github.com/user-attachments/assets/58d6d9c6-c691-442a-bc1c-bfc2c5430169" />
